### PR TITLE
Resolves issue #16.  Uses $(".journal").delegate(".action", "hover", ... 

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -2,17 +2,14 @@
   Array.prototype.last = function() {
     return this[this.length - 1];
   };
+
   $(function() {
     var LOCAL_STORED_LIST, addJournal, addToLocalStored, format, getFromLocalStorage, getItem, localId, localStored, locallyStored, plugins, pushToLocal, pushToServer, put_edit, refresh, resolve_links, text_editor, useLocalStorage;
     resolve_links = function(string) {
       return string.replace(/\[\[([a-z0-9-]+)\]\]/g, "<a href=\"/$1\">$1</a>").replace(/\[(http.*?) (.*?)\]/g, "<a href=\"$1\">$2</a>");
     };
     addJournal = function(journalElement, edit) {
-      return $("<span /> ").addClass("edit").addClass(edit.type).text(edit.type[0]).attr('data-item-id', edit.id).mouseover(function() {
-        return $("[id=" + edit.id + "]").addClass("edited");
-      }).mouseout(function() {
-        return $("[id=" + edit.id + "]").removeClass("edited");
-      }).appendTo(journalElement);
+      return $("<span /> ").addClass("edit").addClass(edit.type).text(edit.type[0]).attr('data-item-id', edit.id).appendTo(journalElement);
     };
     put_edit = function(pageElement, edit) {
       if (useLocalStorage()) {
@@ -291,5 +288,12 @@
     return useLocalStorage = function() {
       return $(".local-editing").is(":checked");
     };
-  });
-}).call(this);
+  });   
+}).call(this);  
+
+$(function(){
+  // Highlighting upon div.journal>span:hover
+  $(".journal").delegate(".action", "hover", function(){
+    $( "#" + $(this).data("itemId") ).toggleClass("edited");
+  }); 
+});


### PR DESCRIPTION
Resolves issue #16.  Uses $(".journal").delegate(".action", "hover", ... ) rather than attaching mouseover() and mouseout() events to each div.journal>span.action.

This has the benefit of "wiring" the events before any edits so hover effects work out-of-the-box. This also automatically wires subsequently added ".action" DOM elements.

IMPORTANT: Assumes that Pull Request #15 has landed because this uses ".action", not ".edit" that was previously used.

See Pull Request #15, especially the discussion and the amended files therein.  https://github.com/WardCunningham/Smallest-Federated-Wiki/pull/15

Signed-off-by: Steven Black steveb@stevenblack.com
