### PR TITLE
layout.haml: specify a content-type, suggest UTF-8.

### DIFF
--- a/server/views/layout.haml
+++ b/server/views/layout.haml
@@ -1,6 +1,7 @@
 %html
 	%head
 		%title= $identity['title']
+		%meta(http-equiv="Content-Type" content="text/html; charset=UTF-8")
 		%meta(name="viewport" content="width=530, maximum-scale=0.65")
 		%link(type="image/png" href="/favicon.png" rel="icon")
 		%link(type="text/css" href="/style.css" rel="stylesheet")


### PR DESCRIPTION
Fixes issue #20.

Signed-off-by: Steven Black steveb@stevenblack.com
