### PR TITLE
Enhanced checkbox /w label, hover cues

### DIFF
--- a/server/views/layout.haml
+++ b/server/views/layout.haml
@@ -11,5 +11,5 @@
 		.main
 			=yield
 		%br{:clear => 'all'}
-		%input.local-editing{:type => "checkbox"}
-			Local editing
+		%input{:type => "checkbox", :id => "localEditing", :class => "local_editing clickable"}
+		%label{:for => "localEditing",  :class => "clickable"} Local editing

--- a/server/views/style.sass
+++ b/server/views/style.sass
@@ -85,3 +85,6 @@ textarea
 
 .factory p
   padding: 10px
+
+.clickable:hover
+  cursor: pointer


### PR DESCRIPTION
style.sass: utility class .clickable makes the cursor a pointer upon :hover

layout.haml: make "Local editing" a bona-fide label attached to the checkbox control to increase the click-target size, and make both class .clickable to show visual cues.

Resolves Issue #22

Signed-off-by: Steven Black steveb@stevenblack.com
