### PR TITLE
Resolves issue #26.  client.coffee, in resolve_links, second .replace use

### DIFF
--- a/client/client.coffee
+++ b/client/client.coffee
@@ -5,7 +5,7 @@ $ ->
   resolve_links = (string) ->
     string
       .replace(/\[\[([a-z0-9-]+)\]\]/g, "<a class=\"internal\" href=\"/$1.html\" data-page-name=\"$1\">$1</a>")
-      .replace /\[(http.*?) (.*?)\]/g, "<a class=\"external\" href=\"$1\">$2</a>"
+      .replace(/\[(http.*?) (.*?)\]/g, "<a class=\"external\" href=\"$1\">$2</a>")
 
   $('.main').delegate '.internal', 'click', (e) ->
     e.preventDefault()


### PR DESCRIPTION
Resolves issue #26.  client.coffee, in resolve_links, second .replace uses parenthesis to wrap its argument for consistency.

Signed-off-by: Steven Black steveb@stevenblack.com
