### PR TITLE
bindingas are like co-operative multi-tasking - each plugin needs to make

### DIFF
--- a/client/client.coffee
+++ b/client/client.coffee
@@ -71,6 +71,8 @@ $ ->
         if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s
           textarea.focusout()
           return false
+      .bind 'dblclick', (e) ->
+        return false; #don't pass dblclick on to the div, as it'll reload
 
     div.html textarea
     textarea.focus()

--- a/client/client.js
+++ b/client/client.js
@@ -97,6 +97,8 @@
           textarea.focusout();
           return false;
         }
+      }).bind('dblclick', function(e) {
+        return false;
       });
       div.html(textarea);
       return textarea.focus();


### PR DESCRIPTION
bindingas are like co-operative multi-tasking - each plugin needs to make sure it plays nicely with itself
   this commit fixes a bug where dbclicking on a textarea re-loads the textarea, thus losing your typing - returning false means that dbclick select works as it should again :)
