### PR TITLE
initial demo of using jsonp to allow the client.js to get a page from ano

### DIFF
--- a/node.js/server.coffee
+++ b/node.js/server.coffee
@@ -1,6 +1,7 @@
 http = require 'http'
 fs = require 'fs'
 qs = require 'querystring'
+url = require 'url'
     
 port = 8888
 
@@ -28,6 +29,11 @@ filetype = {
 
 process.serve_url = (req, res) ->
     file = req.url[1..]
+    
+    urlparams = url.parse(req.url, true)
+    console.log urlparams
+    jsonpCallback = urlparams.query.callback
+    console.log 'callback='+jsonpCallback
 
     if req.method == 'PUT'
        #nasty hack, as we're only putting pages atm, and the URI's are :(
@@ -81,8 +87,13 @@ process.serve_url = (req, res) ->
           status = 404
         data = ""
       console.log 'status: '+ status
-      #console.log ' contentType: '+ contentType
+      if jsonpCallback
+        contentType = 'text/javascript'
+      console.log ' contentType: '+ contentType
       if status is 200
+          if jsonpCallback
+            data = jsonpCallback+'( '+data+' )'
+
           res.writeHead 200,
               'Content-Type': contentType
               'Content-Length': data.length + 1

--- a/server/server.rb
+++ b/server/server.rb
@@ -63,8 +63,13 @@ class Controller < Sinatra::Base
   end
 
   get %r{^/([a-z0-9-]+)\.json$} do |name|
-    content_type 'application/json'
-    JSON.pretty_generate(get_page(name))
+    if defined? params['callback'] then
+      content_type 'text/javascript'
+      params['callback'] + '( ' + JSON.pretty_generate(get_page(name)) + ' )'
+    else
+      content_type 'application/json'
+      JSON.pretty_generate(get_page(name))
+    end
   end
 
   put %r{^/page/([a-z0-9-]+)/action$} do |name|


### PR DESCRIPTION
initial demo of using jsonp to allow the client.js to get a page from another wiki-server - add alink of the style [[remoteserver:1111|welcome-visitors]] - but you must make sure both servers are running a jsonp enabled wiki
  note that this makes the /remote uri redundant.. (though i've only tested viewing)

please don't merge into master - this is really just to show you what I'm talking about wrt using _JSONP_ for REST and Fork or remote wiki pages.

alot of client code still points to the wrong url's - _show source_ for eg - a little refactoring to extract out the build URL code should simplify that tho
