### PR TITLE
Porting the server to express in coffeescript on node

### DIFF
--- a/client/static.html
+++ b/client/static.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>New Simplest Federated Wiki Install</title>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, height=device-height, initial-scale=1.0, user-scalable=no' name='viewport'>
+    <link href='/favicon.png' rel='icon' type='image/png'>
+    <link href='/style.css' rel='stylesheet' type='text/css'>
+    <script src='/js/jquery-1.6.2.min.js' type='text/javascript'></script>
+    <script src='/js/jquery-ui-1.8.16.custom.min.js' type='text/javascript'></script>
+    <link href='/js/jquery-ui-1.8.16.custom.css' rel='stylesheet' type='text/css'>
+    <script type="text/javascript" src="/js/history.min.js"></script>
+    <script type="text/javascript" src="/js/history.jquery.min.js"></script>
+    <script type="text/javascript" src="/js/underscore-min.js"></script>
+    <script src='/client.js' type='text/javascript'></script>
+  </head>
+  <body>
+    <div class='main'>
+      <div class='page' id='welcome-visitors'>
+      </div>
+    </div>
+    <br clear='all'>
+    <input class='local_editing clickable' id='localEditing' type='checkbox'>
+    <label class='clickable' for='localEditing'>Local editing</label>
+  </body>
+</html>

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,166 @@
+.error {
+  color: #bb0000; }
+
+body {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: absolute;
+  background: #eeeeee url("/crosses.png");
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  font-family: "Helvetica Neue", helvetica, Verdana, Arial, Sans;
+  line-height: 1.3;
+  color: #333333; }
+
+.main {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: absolute;
+  bottom: 60px;
+  margin: 0;
+  width: 10000%; }
+
+header,
+footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  height: 20px;
+  padding: 10px;
+  font-size: 80%;
+  z-index: 1000;
+  color: #555566; }
+
+header {
+  top: 0; }
+
+footer {
+  bottom: 0; }
+
+.story {
+  padding-bottom: 5px; }
+
+.chart,
+.image {
+  float: right;
+  margin-left: 0.4em;
+  margin-bottom: 0.4em;
+  background: #eeeeee;
+  padding: 0.8em;
+  width: 40%; }
+
+.image img {
+  width: 100%; }
+
+.journal {
+  margin-top: 2px;
+  clear: both;
+  background-color: #eeeeee;
+  overflow: auto;
+  padding: 3px; }
+
+.action.fork {
+  color: black; }
+
+.action {
+  background-color: #cccccc;
+  color: #666666;
+  text-align: center;
+  text-decoration: none;
+  padding: 0.2em;
+  margin: 3px;
+  float: left;
+  width: 1em; }
+
+.target {
+  background-color: #ffffcc !important; }
+
+.factory p,
+.chart p,
+.footer a,
+.image p {
+  text-align: center;
+  margin-bottom: 0;
+  color: gray;
+  font-size: 70%; }
+
+.federatedWiki .cite {
+  margin-top: 0;
+  color: gray;
+  font-size: 70%; }
+
+p.readout {
+  text-align: center;
+  font-size: 300%;
+  color: black;
+  font-weight: bold;
+  margin: 0; }
+
+.footer {
+  clear: both;
+  margin-bottom: 1em; }
+
+.page {
+  float: left;
+  margin: 0.5em;
+  padding: 0 2em;
+  width: 26em;
+  background-color: white;
+  height: 100%;
+  overflow: auto;
+  box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.2); }
+  .page.active {
+    box-shadow: 2px 1px 24px rgba(0, 0, 0, 0.4);
+    z-index: 10; }
+
+.page.local {
+  background-color: #fbfbef; }
+
+.factory,
+textarea {
+  font-size: inherit;
+  width: 100%;
+  height: 150px; }
+
+.factory {
+  clear: both;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  background-color: #eeeeee; }
+
+.factory p {
+  padding: 10px; }
+
+.clickable:hover {
+  cursor: pointer; }
+
+@media all and (max-width: 400px) {
+  .page {
+    width: 0.9%;
+    margin: 0.01%;
+    padding: 0.04%; } }
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+  margin-right: 10px; }
+
+::-webkit-scrollbar-button:start:decrement,
+::-webkit-scrollbar-button:end:increment {
+  height: 30px;
+  display: block;
+  background-color: transparent; }
+
+::-webkit-scrollbar-track-piece {
+  background-color: #eeeeee;
+  -webkit-border-radius: 6px; }
+
+::-webkit-scrollbar-thumb:vertical {
+  height: 50px;
+  background-color: #cccccc;
+  border: 1px solid #eeeeee;
+  -webkit-border-radius: 6px; }

--- a/node-express/app.coffee
+++ b/node-express/app.coffee
@@ -1,0 +1,151 @@
+# app.coffee
+
+express = require('express')
+fs = require('fs')
+path = require('path')
+http = require('http')
+
+
+# All user defineable options
+
+opt =
+  port: 3000
+  host: ''                                # Anything falsey will accept all hosts
+  root: path.normalize("#{__dirname}/..") # App root defaults to one level above cwd
+  db: path.join("..", "data/pages")
+
+
+# App configuration
+
+app = module.exports = express.createServer()
+
+app.configure( ->
+  #app.set('views', '../server/views')
+  #app.register('.haml', require('hamljs'))
+  #app.set('view engine', 'haml')
+  app.use(express.bodyParser())
+  app.use(express.methodOverride())
+  app.use(app.router)
+  app.use(express.static('../client'))
+)
+
+app.configure('development', ->
+  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }))
+)
+
+app.configure('production', ->
+  app.use(express.errorHandler())
+)
+
+# Redirects
+
+app.redirect('index', (req, res) ->
+  '/static.html'
+  )
+
+# Get routes
+
+app.get('/', (req, res) ->
+  res.redirect('index')
+)
+
+app.get('*.json', (req, res) ->
+  file = req.params[0]
+  fs.readFile(path.join(opt.db, file), (err, data) =>
+    if err then throw err
+    res.json(JSON.parse(data))
+  )
+)
+
+viewdomain = /// ^/(
+  (view|([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+))
+  /[a-z0-9-]+(/
+  (view|([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+))
+  /[a-z0-9-]+)*
+)$ ///
+
+app.get(viewdomain, (req, res) ->
+  # TODO: Make this actually render the template instead of redirecting to index
+  elements = req.params[0].split('/')
+  pages = while ((site = elements.shift()) and (id = elements.shift()))
+    if site is 'view' or site is 'my'
+      {id}
+    else
+      {id, site}
+  res.redirect('index')
+)
+
+app.get('/plugins/factory.js', (req, res) ->
+  catalog = """
+            window.catalog = {
+              "ByteBeat": {"menu": "8-bit Music by Formula"},
+              "MathJax": {"menu": "TeX Formatted Equations"},
+              "Calculator": {"menu": "Running Sums for Expenses"}
+            };
+
+            """
+  fs.readFile("#{opt.root}/client/plugins/meta-factory.js", (err, data) =>
+    if err then throw err
+    res.header('Content-Type', 'application/javascript')
+    res.send(catalog + data)
+  )
+)
+
+app.get('/*', (req, res, next) ->
+  file = req.params[0]
+  next()
+)
+
+# Put routes
+
+app.put(/^\/page\/([a-z0-9-]+)\/action$/i, (req, res) ->
+  action = JSON.parse(req.body.action)
+  # TODO: implement action.fork
+  fs.readFile(path.join(opt.db, req.params[0]), (err, page) =>
+    if err then throw err
+    page = JSON.parse(page)
+    switch action.type
+      when 'move'
+        oldstory = page.story
+        page.story = []
+        for id in action.order
+          for p in oldstory
+            if id is p.id
+              page.story.push p
+        
+      when 'add'
+        before = -1
+        for i in page.story
+          if action.after is i.id
+            before = page.story.indexOf(i)
+        before += 1
+        page.story.splice(before, 0, action.item)
+        
+      when 'remove'
+        for i in page.story
+          if i.id is action.id
+            page.story.splice(page.story.indexOf(i), 1)
+
+      when 'edit'
+        for i in page.story
+          if i.id is action.id
+            page.story.splice(page.story.indexOf(i), 1, action.item)
+
+      else
+        console.log "Unfamiliar action: #{action}"
+
+    if not page.journal
+      page.journal = []
+    page.journal.push(action)
+    fs.writeFile(path.join(opt.db, req.params[0]), JSON.stringify(page), (err) =>
+      if err then throw err
+      res.send('ok')
+      console.log 'saved'
+    )
+  )
+)
+
+app.listen(opt.port, opt.host if opt.host)
+
+
+console.log("Smallest Federated Wiki server listening on #{app.address().port} in mode: #{app.settings.env}")

--- a/node-express/package.json
+++ b/node-express/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "sfwiki-express"
+  , "version": "0.0.1"
+  , "private": true
+  , "dependencies": {
+      "express": ">= 2.5.1"
+  }
+}


### PR DESCRIPTION
Hey guys, I'm working on porting the server from Sinatra to Express, this pull request is a mostly working prototype with simple file io.  It still needs quite a lot of work on the details, but the biggest problem is that it uses static HTML and CSS instead of rendering from templates.  I've copied the hand edited versions I'm using to /client temporarily, hopefully won't need them for long.

Any thoughts on what to do about the templates? Unfortunately Haml can't be used directly in node, there are haml js implementations that aren't that different, and jade, which is the node/express evolution of haml, as well as other template options which aren't really native to either framework, but may be workable in both like mustache/handlebars.  Or I could try to adapt the client side buildPage and not worry about templates.  I like the idea of not having to maintain different templates for parallel implementations, but I don't really have any clear solutions.

thanks,
--nick
