### PR TITLE
Preserves federated site origin in url

### DIFF
--- a/client/client.coffee
+++ b/client/client.coffee
@@ -332,7 +332,7 @@ $ ->
 
   setState = (state) ->
     if History.enabled
-      url = ("/view/#{page}" for page in state.pages).join('') # + "##{state.active}"
+      url = ("/#{state.locs?[idx] or 'view'}/#{page}" for page, idx in state.pages).join('') # + "##{state.active}"
       History.pushState state, state.active, url
 
   setActive = (page) ->
@@ -373,7 +373,7 @@ $ ->
       when LEFTARROW then -1
       when RIGHTARROW then +1
     if direction && History.enabled
-      state = History.getState().data;
+      state = History.getState().data
       newIndex = state.pages.indexOf(state.active) + direction
       if 0 <= newIndex < state.pages.length
         state.active = state.pages[newIndex]
@@ -381,6 +381,10 @@ $ ->
 
   pagesInDom = () ->
     $.makeArray $(".page").map (_, el) -> el.id
+
+  locsInDom = () ->
+    $.makeArray $(".page").map (_, el) ->
+      $(el).data('site') or 'view'
 
   createPage = (name, loc) ->
     if loc and (loc isnt ('view' or 'my'))
@@ -404,7 +408,7 @@ $ ->
       #TODO: this is a cut,paste&hack from a few lines above - refactor out
       if useLocalStorage() and json = localStorage[pageElement.attr("id")]
         #set the dialog content..
-        window.dialog.dialog('open');
+        window.dialog.dialog('open')
       else
         pageElement = $(this).parent().parent()
         slug = $(pageElement).attr('id')
@@ -413,7 +417,7 @@ $ ->
         resource = if site? then "remote/#{site}/#{slug}" else slug
         $.get "/#{resource}.json?random=#{randomBytes(4)}", "", (page) ->
           window.dialog.html($('<pre/>').text(JSON.stringify(page, null, 2)))
-          window.dialog.dialog( "option", "title", "Source for: "+slug );
+          window.dialog.dialog( "option", "title", "Source for: "+slug )
           window.dialog.dialog('open')
 
     .delegate '.page', 'click', (e) ->
@@ -428,7 +432,7 @@ $ ->
       # FIXME: can open page multiple times with shift key
 
       if History.enabled
-        setState {pages: pagesInDom(), active: name}
+        setState {pages: pagesInDom(), active: name, locs: locsInDom() }
 
     .delegate '.action', 'hover', ->
       id = $(this).data('itemId')
@@ -445,7 +449,7 @@ $ ->
         .each refresh
 
       if History.enabled
-        setState {pages: pagesInDom(), active: name}
+        setState {pages: pagesInDom(), active: name, locs: locsInDom() }
 
   useLocalStorage = -> $(".login").length > 0
 
@@ -457,4 +461,4 @@ $ ->
   $('.page').each refresh
 
   startPages = pagesInDom()
-  setState { pages: startPages, active: startPages[startPages.length-1]}
+  setState { pages: startPages, active: startPages[startPages.length-1], locs: locsInDom() }

--- a/client/client.js
+++ b/client/client.js
@@ -7,7 +7,7 @@
   };
 
   $(function() {
-    var LEFTARROW, RIGHTARROW, addToJournal, asSlug, createPage, doInternalLink, doPlugin, findPage, formatTime, getItem, getPlugin, i, idx, j, pagesInDom, pushToLocal, pushToServer, putAction, randomByte, randomBytes, refresh, resolveFrom, resolveLinks, scripts, scrollTo, setActive, setState, showState, startPages, textEditor, urlLocs, urlPage, urlPages, useLocalStorage, _len;
+    var LEFTARROW, RIGHTARROW, addToJournal, asSlug, createPage, doInternalLink, doPlugin, findPage, formatTime, getItem, getPlugin, i, idx, j, locsInDom, pagesInDom, pushToLocal, pushToServer, putAction, randomByte, randomBytes, refresh, resolveFrom, resolveLinks, scripts, scrollTo, setActive, setState, showState, startPages, textEditor, urlLocs, urlPage, urlPages, useLocalStorage, _len;
     window.wiki = {};
     window.dialog = $('<div></div>').html('This dialog will show every time!').dialog({
       autoOpen: false,
@@ -424,15 +424,15 @@
       }
     };
     setState = function(state) {
-      var page, url;
+      var idx, page, url;
       if (History.enabled) {
         url = ((function() {
-          var _i, _len, _ref, _results;
+          var _len, _ref, _ref2, _results;
           _ref = state.pages;
           _results = [];
-          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-            page = _ref[_i];
-            _results.push("/view/" + page);
+          for (idx = 0, _len = _ref.length; idx < _len; idx++) {
+            page = _ref[idx];
+            _results.push("/" + (((_ref2 = state.locs) != null ? _ref2[idx] : void 0) || 'view') + "/" + page);
           }
           return _results;
         })()).join('');
@@ -499,6 +499,11 @@
         return el.id;
       }));
     };
+    locsInDom = function() {
+      return $.makeArray($(".page").map(function(_, el) {
+        return $(el).data('site') || 'view';
+      }));
+    };
     createPage = function(name, loc) {
       if (loc && (loc !== ('view' || 'my'))) {
         return $("<div/>").attr('id', name).attr('data-site', loc).addClass("page");
@@ -541,7 +546,8 @@
       if (History.enabled) {
         return setState({
           pages: pagesInDom(),
-          active: name
+          active: name,
+          locs: locsInDom()
         });
       }
     }).delegate('.action', 'hover', function() {
@@ -558,7 +564,8 @@
       if (History.enabled) {
         return setState({
           pages: pagesInDom(),
-          active: name
+          active: name,
+          locs: locsInDom()
         });
       }
     });
@@ -595,7 +602,8 @@
     startPages = pagesInDom();
     return setState({
       pages: startPages,
-      active: startPages[startPages.length - 1]
+      active: startPages[startPages.length - 1],
+      locs: locsInDom()
     });
   });
 


### PR DESCRIPTION
Just a small change for now, adds a locsInDom helper function to make an array of the page locations that have already been written to the dom, to go with pagesInDom.  And adds locs to the state data object to track the locations, and uses that when writing the url to keep the location information.  Has fail safes everywhere, so if a location doesn't exist at any stage 'view' gets used instead.
