### PR TITLE
Make help.github.com clickable

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -105,7 +105,7 @@ Looking For Code Bloat
 
 Try this command to see if any code files have grown unpleasantly large.
 
-	wc -l `find . | perl -ne 'next if /jquery/; print if /\.(rb|haml|sass|coffee)$/'`
+	wc -l `find . | perl -ne 'next if /jquery/; print if /\.(rb|haml|sass|coffee)$/'` | sort -rgb
 
 License
 =======


### PR DESCRIPTION
In the Install and Launch section is a good advice. Learn more from
GitHub. Instead of a clickable link a instruction is given. This
is confusing.

In this commit the instruction is changed into a bulleted link.
