### PR TITLE
make coffee-script a module of express server

### DIFF
--- a/server/express/bin/server
+++ b/server/express/bin/server
@@ -1,67 +1,14 @@
-#!/usr/bin/env coffee
-# server
-# Cli for the Smallest-Federated-Wiki express server
+#!/usr/bin/env node
+// server
+// Cli for the Smallest-Federated-Wiki express server
 
-path = require 'path'
-optimist = require 'optimist'
-server = require '../'
-bouncy = require 'bouncy'
-farm = require '../lib/farm'
+require('coffee-script');
 
-# Handle command line options
+// the following bits copied from the coffee-script binaries,
+// used to find the ../lib/command.coffee module
 
-argv = optimist
-  .usage('Usage: $0')
-  .options('d',
-    alias     : 'data'
-    default   : ''
-    describe  : 'location of flat file data'
-  )
-  .options('h',
-    alias     : 'help'
-    boolean   : true
-    describe  : 'Show this help info and exit'
-  )
-  .options('o',
-    alias     : 'host'
-    default   : ''
-    describe  : 'Host to accept connections on, falsy == any'
-  )
-  .options('u',
-    alias     : 'url'
-    default   : ''
-    describe  : 'Url to be used for the realm in openID'
-  )
-  .options('p',
-    alias     : 'port'
-    default   : 3000
-    describe  : 'Port'
-  )
-  .options('r',
-    alias     : 'root'
-    default   : path.join(__dirname, '..', '..', '..')
-    describe  : 'Application root folder'
-  )
-  .options('f',
-    alias     : 'farm'
-    boolean   : true
-    describe  : 'Turn on the farm?'
-  )
-  .options('F',
-    alias     : 'FarmPort'
-    default   : 40000
-    describe  : 'Port to start farm servers on.'
-  )
-  .argv
+var path = require('path');
+var fs   = require('fs');
+var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-# If h/help is set print the generated help message and exit.
-if argv.h
-  optimist.showHelp()
-  process.exit()
-
-# If f/farm is set call../lib/farm.coffee with argv object, else call
-# ../lib/server.coffee with argv object.
-if argv.f
-  farm(argv)
-else
-  server(argv)
+require(lib + '/command');

--- a/server/express/lib/command.coffee
+++ b/server/express/lib/command.coffee
@@ -1,0 +1,65 @@
+# Cli for the Smallest-Federated-Wiki express server
+
+path = require 'path'
+optimist = require 'optimist'
+server = require './server'
+bouncy = require 'bouncy'
+farm = require './farm'
+
+# Handle command line options
+
+argv = optimist
+  .usage('Usage: $0')
+  .options('d',
+    alias     : 'data'
+    default   : ''
+    describe  : 'location of flat file data'
+  )
+  .options('h',
+    alias     : 'help'
+    boolean   : true
+    describe  : 'Show this help info and exit'
+  )
+  .options('o',
+    alias     : 'host'
+    default   : ''
+    describe  : 'Host to accept connections on, falsy == any'
+  )
+  .options('u',
+    alias     : 'url'
+    default   : ''
+    describe  : 'Url to be used for the realm in openID'
+  )
+  .options('p',
+    alias     : 'port'
+    default   : 3000
+    describe  : 'Port'
+  )
+  .options('r',
+    alias     : 'root'
+    default   : path.join(__dirname, '..', '..', '..')
+    describe  : 'Application root folder'
+  )
+  .options('f',
+    alias     : 'farm'
+    boolean   : true
+    describe  : 'Turn on the farm?'
+  )
+  .options('F',
+    alias     : 'FarmPort'
+    default   : 40000
+    describe  : 'Port to start farm servers on.'
+  )
+  .argv
+
+# If h/help is set print the generated help message and exit.
+if argv.h
+  optimist.showHelp()
+  process.exit()
+
+# If f/farm is set call../lib/farm.coffee with argv object, else call
+# ../lib/server.coffee with argv object.
+if argv.f
+  farm(argv)
+else
+  server(argv)

--- a/server/express/package.json
+++ b/server/express/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "coffee-script": ">=1.2.0",
     "express": ">= 2.5.1",
     "mkdirp": ">= 0.0.1",
     "canvas": ">= 0.0.1",


### PR DESCRIPTION
These are some changes for issue #96 :

**express server should include coffee-script as a module**
- moved the bulk of what used to be in bin/server to
  lib/command.coffee
- changed bin/coffee to be a js file, not coffee, and have
  it invoke lib/command.coffee via require()
- added coffee-script to package.json
