### PR TITLE
Big changes to server/express/page.coffee

### DIFF
--- a/server/express/lib/farm.coffee
+++ b/server/express/lib/farm.coffee
@@ -1,12 +1,14 @@
-# ** farm.coffee **
+# **farm.coffee *
 # The farm module works by putting a bouncy host based proxy
 # in front of servers that it creates 
+
 path = require 'path'
-server = require '../'
 bouncy = require 'bouncy'
+server = require '../'
 
 module.exports = exports = (argv) ->
   hosts = {}
+  runningServers = []
   
   nextport = do ->
     port = argv.F - 1
@@ -23,8 +25,6 @@ module.exports = exports = (argv) ->
       newargv.p = hosts[req.headers.host]
       newargv.d = path.join(argv.r or path.join(__dirname, '..', '..', '..'), 'data', req.headers.host)
       newargv.u = "http://#{req.headers.host}"
-      server(newargv)
+      runningServers.push(server(newargv))
       bounce(hosts[req.headers.host])
   ).listen(argv.p)
-
-# Create an instance of server using command line arguments and defaults.

--- a/server/express/lib/page.coffee
+++ b/server/express/lib/page.coffee
@@ -10,77 +10,98 @@ random_id = require('./random_id')
 
 # Set up an empty object named itself that will have public methods
 # added to it and be exported.
-module.exports = exports = itself = {}
+module.exports = exports = (argv) ->
 
-#### Private utility methods.
-load_parse = (loc, cb) ->
-  fs.readFile(loc, (err, data) ->
-    if err then throw err
-    cb(JSON.parse(data))
-  )
-
-load_parse_copy = (defloc, file, cb) ->
-  fs.readFile(defloc, (err, data) ->
-    if err then throw err
-    page = JSON.parse(data)
-    cb(page)
-    itself.put(file, page, (err) ->
+  #### Private utility methods.
+  load_parse = (loc, cb) ->
+    fs.readFile(loc, (err, data) ->
+      if err then throw err
+      cb(JSON.parse(data))
+    )
+  
+  load_parse_copy = (defloc, file, cb) ->
+    fs.readFile(defloc, (err, data) ->
+      if err then throw err
+      page = JSON.parse(data)
+      cb(page)
+      itself.put(file, page, (err) ->
+        if err then throw err
+      )
+    )
+  
+  blank_page = (file, cb) ->
+    freshpage = {
+      title: file
+      story: [
+        { type: 'factory', id: random_id() }
+      ]
+      journal: []
+    }
+    itself.put(file, freshpage, (err) ->
       if err then throw err
     )
-  )
-
-blank_page = (file, cb) ->
-  freshpage = {
-    title: file
-    story: [
-      { type: 'factory', id: random_id() }
-    ]
-    journal: []
-  }
-  itself.put(file, freshpage, (err) ->
-    if err then throw err
-  )
-  cb(freshpage)
-
-#### Exported functions
-# Setup just takes the same argv element as everywhere else, so that
-# page.coffee can find everything it needs
-itself.setup = (@argv) ->
-
-# get takes a slug and a callback, it then calls the callback with the page
-# it wanted, or the same named page from default-data, or creates a blank page
-# and sends it back.
-itself.get = (file, cb) ->
-  loc = path.join(@argv.db, file)
-  path.exists(loc, (exists) =>
-    if exists
-      load_parse(loc, cb)
-    else
-      defloc = path.join(@argv.r, 'default-data', 'pages', file)
-      path.exists(defloc, (exists) ->
-        if exists
-          load_parse_copy(defloc, file, cb)
-        else
-          blank_page(file, cb)
-      )
-  )
+    cb(freshpage)
   
-# put takes a slugged name, the page as a json object, and a callback.
-# calls cb with an err if anything goes wrong.
-itself.put = (file, page, cb) ->
-  loc = path.join(@argv.db, file)
-  page = JSON.stringify(page, null, 2)
-  path.exists(path.dirname(loc), (exists) ->
-    if exists
-      fs.writeFile(loc, page, (err) ->
-        cb(err)
+  queue = []
+  
+  fileio = (file, page, cb) ->
+    loc = path.join(argv.db, file)
+    unless page?
+      path.exists(loc, (exists) =>
+        if exists
+          load_parse(loc, cb)
+        else
+          defloc = path.join(argv.r, 'default-data', 'pages', file)
+          path.exists(defloc, (exists) ->
+            if exists
+              load_parse_copy(defloc, file, cb)
+            else
+              blank_page(file, cb)
+          )
       )
     else
-      mkdirp(path.dirname(loc), 0777, (err) ->
-        if err then throw err
-        fs.writeFile(loc, page, (err) ->
-          cb(err)
-        )
+      page = JSON.stringify(page, null, 2)
+      path.exists(path.dirname(loc), (exists) ->
+        if exists
+          fs.writeFile(loc, page, (err) ->
+            cb(err)
+          )
+        else
+          mkdirp(path.dirname(loc), 0777, (err) ->
+            if err then throw err
+            fs.writeFile(loc, page, (err) ->
+              cb(err)
+            )
+          )
       )
-  )
+  
+  working = 0
+  serial = (item) ->
+    if item
+      working = 1
+      fileio(item.file, item.page, (data) ->
+        process.nextTick( ->
+          serial(queue.shift())
+        )
+        item.cb(data)
+      )
+    else
+      working = 0
+  
+  itself = {}
+  # get takes a slug and a callback, it then calls the callback with the page
+  # it wanted, or the same named page from default-data, or creates a blank page
+  # and sends it back.
+  itself.get = (file, cb) ->
+    queue.push({file, page: null, cb})
+    serial(queue.shift()) unless working
+  
+    
+  # put takes a slugged name, the page as a json object, and a callback.
+  # calls cb with an err if anything goes wrong.
+  #  Async, sequential queue for persisting data.
+  itself.put =  (file, page, cb) ->
+      queue.push({file, page, cb})
+      serial(queue.shift()) unless working
 
+  itself

--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -4,29 +4,27 @@
 # for setting arguments, and spawning servers.  In a complex system
 # you would probably want to replace the CLI/Farm with your own code,
 # and use server.coffee directly.
-#
-#### Dependencies 
-# anything not in the standard library is included in the repo, or
-# can be installed with an:
-#     npm install
-express = require('express')
-fs = require('fs')
-path = require('path')
-http = require('http')
-hbs = require('hbs')
-pagehandler = require('./page.coffee')
-favicon = require('./favicon.coffee')
-passport = require('passport')
-OpenIDstrat = require('passport-openid').Strategy
 
 # Set export objects for node and coffee to a function that generates a sfw server.
 module.exports = exports = (argv) ->
+  #### Dependencies 
+  # anything not in the standard library is included in the repo, or
+  # can be installed with an:
+  #     npm install
+  express = require('express')
+  fs = require('fs')
+  path = require('path')
+  http = require('http')
+  hbs = require('hbs')
+  favicon = require('./favicon.coffee')
+  passport = require('passport')
+  OpenIDstrat = require('passport-openid').Strategy
   # defaultargs.coffee exports a function that takes the argv object that is passed in and then does its
   # best to supply sane defaults for any arguments that are missing.
   argv = require('./defaultargs')(argv)
 
   # Tell pagehandler where to find data, and default data.
-  pagehandler.setup(argv)
+  pagehandler = require('./page')(argv)
 
   #### Setting up Authentication
   # The owner of a server is simply the open id url that the wiki

--- a/server/express/test/farm.coffee
+++ b/server/express/test/farm.coffee
@@ -1,0 +1,6 @@
+farm = require '../lib/farm.coffee'
+
+describe 'farming', ->
+  describe 'farm.coffee', ->
+    it 'should spawn servers based on incoming hosts', ->
+    it 'should not interfere with other servers', ->

--- a/server/express/test/page.coffee
+++ b/server/express/test/page.coffee
@@ -1,14 +1,12 @@
-page = require '../lib/page.coffee'
 path = require('path')
 random = require('../lib/random_id')
 testid = random()
 argv = require('../lib/defaultargs.coffee')({d: path.join('/tmp', 'sfwtests', testid)})
+page = require('../lib/page.coffee')(argv)
 
 testpage = {title: 'Asdf'}
 
 describe 'page', ->
-  before ->
-    page.setup(argv)
   describe '#page.put()', ->
     it 'should save a page', (done) ->
       page.put('asdf', testpage, (e) ->

--- a/server/express/test/server.coffee
+++ b/server/express/test/server.coffee
@@ -4,6 +4,7 @@ random = require '../lib/random_id'
 testid = random()
 argv = require('../lib/defaultargs.coffee')({d: path.join('/tmp', 'sfwtests', testid), p: 55555})
 fs = require('fs')
+pagehandler = require('../lib/page.coffee')(argv)
 
 describe 'server', ->
   describe '#actionCB()', ->
@@ -19,13 +20,9 @@ describe 'server', ->
     createSend = (test, done) ->
       (str) ->
         console.log str
-        fs.readFile(file, (err, data) ->
-          if err then throw err
-          test(JSON.parse(data))
-          fs.unlink(file, (e) ->
-            console.log 'deleted'
-            done()
-          )
+        pagehandler.get('asdf-test-page', (data) ->
+          test(data)
+          done()
         )
     
     it 'should move the paragraphs to the order given ', (done) ->
@@ -43,7 +40,7 @@ describe 'server', ->
         item: {id: 'a5', type: 'paragraph', text: 'this is the NEW paragraph'}
       })
       test = (page) ->
-        page.story[2].id.should.equal('a5')
+        page.story[3].id.should.equal('a5')
       res.send = createSend(test, done)
       routeCB(req, res)
 
@@ -53,7 +50,8 @@ describe 'server', ->
         id: 'a2'
       })
       test = (page) ->
-        page.story.length.should.equal(3)
+        page.story.length.should.equal(4)
+        page.story[2].id.should.not.equal('a2')
         page.story[1].id.should.not.equal('a2')
       res.send = createSend(test, done)
       routeCB(req, res)
@@ -65,7 +63,7 @@ describe 'server', ->
         id: 'a3'
       })
       test = (page) ->
-        page.story[2].text.should.equal('edited')
+        page.story[1].text.should.equal('edited')
       res.send = createSend(test, done)
       routeCB(req, res)
 
@@ -75,8 +73,8 @@ describe 'server', ->
       })
       test = (page) ->
         page.story.length.should.equal(4)
-        page.story[1].id.should.equal('a2')
-        page.story[2].text.should.equal('this is the third paragraph')
+        page.story[1].id.should.equal('a3')
+        page.story[3].text.should.equal('this is the fourth paragraph')
       res.send = createSend(test, done)
       routeCB(req, res)
 


### PR DESCRIPTION
Fixed the race condition in page.coffee, for now the disk io is serialized using an array as a queue, and changed it so that requiring lib/page now returns a function that constructs an object with the get and put methods when it is called with argv.  This fixes a bug with farmed servers serving each others json.

There is still a problem with authentication returning to the wrong site with farmed servers.

Thanks again to Matt for helping out.
