### PR TITLE
Express: Fixed create, added error to pagehandler cb.

### DIFF
--- a/default-data/pages/asdf-test-page
+++ b/default-data/pages/asdf-test-page
@@ -1,8 +1,0 @@
-{ "title": "Asdf Test Page", "story": [
-        {"id": "a1", "type": "paragraph", "text": "this is the first paragraph"},
-        {"id": "a2", "type": "paragraph", "text": "this is the second paragraph"},
-        {"id": "a3", "type": "paragraph", "text": "this is the third paragraph"},
-        {"id": "a4", "type": "paragraph", "text": "this is the fourth paragraph"}
-      ],
-      "journal": []
-    }

--- a/server/express/test/page.coffee
+++ b/server/express/test/page.coffee
@@ -3,6 +3,7 @@ random = require('../lib/random_id')
 testid = random()
 argv = require('../lib/defaultargs.coffee')({d: path.join('/tmp', 'sfwtests', testid)})
 page = require('../lib/page.coffee')(argv)
+fs = require('fs')
 
 testpage = {title: 'Asdf'}
 
@@ -14,17 +15,33 @@ describe 'page', ->
       )
   describe '#page.get()', ->
     it 'should get a page if it exists', (done) ->
-      page.get('asdf', (got) ->
+      page.get('asdf', (e, got) ->
+        if e then throw e
         got.title.should.equal 'Asdf'
         done()
       )
     it 'should copy a page from default if nonexistant in db', (done) ->
-      page.get('welcome-visitors', (got) ->
+      page.get('welcome-visitors', (e, got) ->
+        if e then throw e
         got.title.should.equal 'Welcome Visitors'
         done()
       )
     it 'should create a page if it exists nowhere', (done) ->
-      page.get(random(), (got) ->
+      page.get(random(), (e, got) ->
+        if e then throw e
         got.should.equal('Page not found')
         done()
       )
+    it 'should eventually write the page to disk', (done) ->
+      test = ->
+        fs.readFile(path.join(argv.db, 'asdf'), (err, data) ->
+          if err then throw err
+          readPage = JSON.parse(data)
+          page.get('asdf', (e, got) ->
+            readPage.title.should.equal got.title
+            done()
+          )
+        )
+      if page.isWorking()
+        page.on('finished', -> test())
+      else test()

--- a/server/express/test/server.coffee
+++ b/server/express/test/server.coffee
@@ -23,20 +23,44 @@ describe 'server', ->
     file = path.join(argv.db, "asdf-test-page")
     res = {}
     # TODO: When race conditions are fixed in lib/page.coffee clean up function below.
-    createSend = (test, done) ->
+    createSend = (test) ->
       (str) ->
         console.log str
-        runningServer.pagehandler.get('asdf-test-page', (data) ->
+        runningServer.pagehandler.get('asdf-test-page', (e, data) ->
+          if e then throw e
           test(data)
-          done()
         )
-    
+
+    it 'should create a page', (done) ->
+      req.body.action = JSON.stringify({
+      type: 'create'
+      item: {
+        title: "Asdf Test Page"
+        story: [
+          {id: "a1", type: "paragraph", text: "this is the first paragraph"}
+          {id: "a2", type: "paragraph", text: "this is the second paragraph"}
+          {id: "a3", type: "paragraph", text: "this is the third paragraph"}
+          {id: "a4", type: "paragraph", text: "this is the fourth paragraph"}
+          ]
+        journal: []
+      }
+      id: 'd5'
+      })
+      test = (page) ->
+        page.title.should.equal('Asdf Test Page')
+        page.journal[0].type.should.equal('create')
+        page.story[0].id.should.equal('a1')
+        done()
+      res.send = createSend(test)
+      routeCB(req, res)
+
     it 'should move the paragraphs to the order given ', (done) ->
       req.body.action = '{ "type": "move", "order": [ "a1", "a3", "a2", "a4"] }'
       test = (page) ->
         page.story[1].id.should.equal('a3')
         page.story[1].id.should.not.equal('a2')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     it 'should add a paragraph', (done) ->
@@ -47,7 +71,8 @@ describe 'server', ->
       })
       test = (page) ->
         page.story[3].id.should.equal('a5')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     it 'should remove a paragraph with given id', (done) ->
@@ -59,7 +84,8 @@ describe 'server', ->
         page.story.length.should.equal(4)
         page.story[2].id.should.not.equal('a2')
         page.story[1].id.should.not.equal('a2')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     it 'should edit a paragraph in place', (done) ->
@@ -70,7 +96,8 @@ describe 'server', ->
       })
       test = (page) ->
         page.story[1].text.should.equal('edited')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     it 'should default to no change', (done) ->
@@ -81,7 +108,8 @@ describe 'server', ->
         page.story.length.should.equal(4)
         page.story[1].id.should.equal('a3')
         page.story[3].text.should.equal('this is the fourth paragraph')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     it 'should refuse to create over a page', (done) ->
@@ -94,7 +122,8 @@ describe 'server', ->
       })
       test = (page) ->
         page.title.should.not.equal('Doh')
-      res.send = createSend(test, done)
+        done()
+      res.send = createSend(test)
       routeCB(req, res)
 
     after( ->


### PR DESCRIPTION
Work has really been conspiring against Wednesday mornings recently :(

This makes create safer, adds error handling to pagehandler call back, and i'm starting to play around with page.coffee as an instance of EventEmitter, giving it more interesting ways to communicate with other modules (The first use is tests that don't until there are no longer outstanding file io jobs in the queue.)

I've abandoned rewriting page.coffee for the moment, I've tried several different courses of action, from streams libraries to a memory store with lazy load/save.  Nothing's really seemed right yet...

Thanks again to my brother @m-n for some pair programming assistance on this one.
