### PR TITLE
Prevent arrows from selecting pages while editing; Format new page titles like their initial link

### DIFF
--- a/client/client.coffee
+++ b/client/client.coffee
@@ -372,7 +372,9 @@ $ ->
             callback(null)
 
     create = (slug, callback) ->
-      page = {title: slug}
+      title = $("""a[href="/#{slug}.html"]""").html()
+      title or= slug
+      page = {title}
       putAction $(pageElement), {type: 'create', id: randomBytes(8), item: page}
       callback page
 

--- a/client/client.js
+++ b/client/client.js
@@ -474,9 +474,11 @@
         });
       };
       create = function(slug, callback) {
-        var page;
+        var page, title;
+        title = $("a[href=\"/" + slug + ".html\"]").html();
+        title || (title = slug);
         page = {
-          title: slug
+          title: title
         };
         putAction($(pageElement), {
           type: 'create',


### PR DESCRIPTION
Hello, just a couple tiny changes. 

When entering text in a text box, the text box will now catch arrow keys so that they only move the cursor, rather than both moving the cursor and selecting the next page.

Creating then clicking on [[New Page]] now creates a page titled "New Page" instead of "new-page".

Changes created with @nrn.
