### PR TITLE
Express: Lots of little things.

### DIFF
--- a/server/express/lib/cli.coffee
+++ b/server/express/lib/cli.coffee
@@ -54,6 +54,9 @@ argv = optimist
     boolean   : true
     describe  : 'Set server to work with the rspec integration tests'
   )
+  .options('id',
+    describe  : 'Set the location of the open id file'
+  )
   .argv
 
 # If h/help is set print the generated help message and exit.

--- a/server/express/lib/defaultargs.coffee
+++ b/server/express/lib/defaultargs.coffee
@@ -12,4 +12,5 @@ module.exports = (argv) ->
   argv.db or= path.join(argv.d, 'pages')
   argv.status or= path.join(argv.d, 'status')
   argv.u or= 'http://localhost' + (':' + argv.p) unless argv.p is 80
+  argv.id or= path.join(argv.status, 'open_id.identity')
   argv

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 
 if USE_NODE
   Capybara.app_host = "http://localhost:33333"
+  Capybara.server_port = 33333
 else
   require File.expand_path(File.join(File.dirname(__FILE__), "../server/sinatra/server"))
 


### PR DESCRIPTION
Updated regex for initial page load to handle trailing / : https://github.com/nrn/Smallest-Federated-Wiki/blob/master/server/express/lib/server.coffee#L202

Refactored http requests from the express server into remoteGet, now properly handles non default ports, and statuses, including 404.  I'm not sure we have the intended client behavior with this, but it seems the same as the reference implementation.

I also added a needed port to the integration test helper, so node is now passing all tests except the should create favicon test.  Should I attempt to hack the test to pass with the local favicon creation when remote returns 404? 

OPENID changed to argv.id, now an option from the command line, and set to the same old value by defaultargs if not provided.

Once again working with @m-n
