### PR TITLE
Express: Cleanup

### DIFF
--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -42,6 +42,11 @@ module.exports = exports = (argv) ->
   # that is passed in and then does its
   # best to supply sane defaults for any arguments that are missing.
   argv = defargs(argv)
+  app.startOpts = do ->
+    options = {}
+    for own k, v of argv
+      options[k] = v
+    options
   # Construct authentication handler.
   passport = new passportImport.Passport()
   # Tell pagehandler where to find data, and default data.
@@ -421,8 +426,6 @@ module.exports = exports = (argv) ->
   # Wait to make sure owner is known before listening.
   setOwner( null, ->
     app.listen(argv.p, argv.o if argv.o)
-    # When server is listening emit a ready event.
-    app.emit "ready"
     console.log("Smallest Federated Wiki server listening on #{app.address().port} in mode: #{app.settings.env}")
   )
   # Return app when called, so that it can be watched for events and shutdown with .close() externally.

--- a/server/express/test/defaultargs.coffee
+++ b/server/express/test/defaultargs.coffee
@@ -6,4 +6,6 @@ describe 'defaultargs', ->
       defaultargs({p: 1234}).p.should.equal(1234)
     it 'should write non give args', ->
       defaultargs().p.should.equal(3000)
+    it 'should modify dependant args', ->
+      defaultargs({r: '/tmp/asdf/'}).db.should.equal('/tmp/asdf/data/pages')
 

--- a/server/express/test/server.coffee
+++ b/server/express/test/server.coffee
@@ -10,7 +10,7 @@ describe 'server', ->
     routeCB = {}
     before((done) ->
       runningServer = server(argv)
-      runningServer.once("ready", ->
+      runningServer.once("listening", ->
         routeCB = runningServer.routes.routes.put[0].callbacks[1]
         done()
       )


### PR DESCRIPTION
Switched to using the listening event that was already being emitted
by the server when ready was emitted, and gave req.headers.host it's
own variable in lib/farm.coffee.

Added a test for checking that generated args are based on given args.

Exposed the starting arguments of the server in the returned object.
