### PR TITLE
Expect UTF-8 encoding, notably for the JSON files storing page data.  

### DIFF
--- a/server/sinatra/server.rb
+++ b/server/sinatra/server.rb
@@ -7,6 +7,8 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 SINATRA_ROOT = File.expand_path(File.dirname(__FILE__))
 APP_ROOT = File.expand_path(File.join(SINATRA_ROOT, "..", ".."))
 
+Encoding.default_external = Encoding::UTF_8
+
 require 'random_id'
 require 'page'
 require 'favicon'


### PR DESCRIPTION
I wrote [a script to convert local markdown files to html, package them as JSON, and HTTP PUT them to a SWF instance](https://github.com/harlantwood/FreePress/blob/master/Thorfile) -- my server was running Sinatra under Passenger on EC2.  The server would crash on every PUT with a message about `Encoding::InvalidByteSequenceError - "\xE2" on US-ASCII`.  The Google bestowed on me the understanding that my JSON was UTF-8, and my Sinatra was not, and this line of code...

```
Encoding.default_external = Encoding::UTF_8
```

...which fixed all my woes, and is the whole of my pull request.
