### PR TITLE
make session store configurable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "png"
 gem "rest-client"
 gem "ruby-openid"
 gem "couchrest"
+gem "memcache-client", :require => 'memcache'
 
 group :development do
   gem 'ruby-debug', :require => 'ruby-debug', :platform => :mri_18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
+    memcache-client (1.8.5)
     mime-types (1.18)
     multi_json (1.0.4)
     netrc (0.7.1)
@@ -112,6 +113,7 @@ DEPENDENCIES
   heroku
   json
   launchy
+  memcache-client
   png
   rack-test (= 0.5.6)
   rest-client

--- a/server/sinatra/server.rb
+++ b/server/sinatra/server.rb
@@ -24,7 +24,11 @@ class Controller < Sinatra::Base
   set :views , File.join(SINATRA_ROOT, "views")
   set :haml, :format => :html5
   set :versions, `git log -10 --oneline` || "no git log"
-  enable :sessions
+  if ENV.include?('SESSION_STORE')
+    use ENV['SESSION_STORE'].split('::').inject(Object) { |mod, const| mod.const_get(const) }
+  else
+    enable :sessions
+  end
   helpers ServerHelpers
 
   Store.set ENV['STORE_TYPE'], APP_ROOT


### PR DESCRIPTION
This makes it possible to specify other session stores than the default <em>Rack::Session::Cookie</em> (which doesn't seem to behave well when the Federated Wiki is run in the <a href="http://www.modrails.com/">Passenger</a> environment).
The store to use is specified by setting the environment variable <em>SESSION_STORE</em> to the name of the class implementing the store, for example:

<blockquote>SESSION_STORE="Rack::Session::Memcache"</blockquote>

Note that all prerequisites of the session store implementation specified in this way must be added to the <em>Gemfile</em> so that they are on the ruby load path and can be loaded when needed. (This patch adds <em>memcache-client</em> to the <em>Gemfile</em>, which is a prerequisite of the <em>Rack::Session::Memcache</em>.)
