### PR TITLE
Increase coverage and simplify revision.coffee

### DIFF
--- a/client/lib/revision.coffee
+++ b/client/lib/revision.coffee
@@ -8,9 +8,8 @@ create = (revIndex, data) ->
   journal = data.journal
   revTitle = data.title
   revStory = []
-  revJournal = []
-  for journalEntry in journal.slice 0, (+revIndex)+1
-    revJournal.push(journalEntry)
+  revJournal = journal[0..(+revIndex)]
+  for journalEntry in revJournal
     revStoryIds = revStory.map (storyItem) -> storyItem.id
     switch journalEntry.type
       when 'create'


### PR DESCRIPTION
As my entry to the Take-Out challenge I suggest refactoring the code in revision.coffee. However, before making changes/improvements I noticed that there's not a lot of test coverage around that function. So I suggest adding more tests for the behavior of each operation (create, add, move, edit, and remove) and then tackling a smell I noticed:

Two places deal with adding the journalEntry.item to revStory when "after" is not defined (there's an explicit check and then a defensive guard variable that do the same thing

Also, because I don't yet completely understand what goes in revStory, I have a question: would items with the same story id appear more than once in that array? If not, another idea to simplify that code would be to use loop comprehensions.

Is that a valid and valuable entry to the challenge? That's what I managed to find by skimming through the code in the airport so I would work on this during he week.

Thanks for the keynote at the TW Away Day!
