### PR TITLE
Display the remote site name in the footer

### DIFF
--- a/client/lib/refresh.coffee
+++ b/client/lib/refresh.coffee
@@ -148,7 +148,8 @@ module.exports = refresh = wiki.refresh = ->
                             """
       footerElement
         .append('<a id="license" href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a> . ')
-        .append("<a class=\"show-page-source\" href=\"/#{slug}.json?random=#{util.randomBytes(4)}\" title=\"source\">JSON</a>")
+        .append("<a class=\"show-page-source\" href=\"/#{slug}.json?random=#{util.randomBytes(4)}\" title=\"source\">JSON</a> . ")
+        .append("<a>"+siteFound+"</a>")
 
       state.setUrl()
 


### PR DESCRIPTION
there are some cases where null and undefined need to be handled, but its still quite useful as-is.
