### PR TITLE
sitemap.json swallow exceptions

### DIFF
--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -342,7 +342,7 @@ module.exports = exports = (argv) ->
           res.send('Favicon Saved')
         )
       else
-        mkdirp(argv.status,   0777, ->
+        mkdirp(argv.status, 0777, ->
           fs.writeFile(favLoc, buf, (e) ->
             if e then throw e
             res.send('Favicon Saved')
@@ -378,7 +378,9 @@ module.exports = exports = (argv) ->
       numFiles = files.length 
       for file in files
         pagehandler.get(file, (e, page, status) ->
-          if e then throw e
+          if e 
+            console.log(['pagehandler exception', e])
+            return
           
           # create synopsis
           if (page.synopsis?)


### PR DESCRIPTION
I think you were getting an uncaught exception that never got caught. I think this might be a way to keep the exception from crashing the server.

We should maybe go through this function in the debugger to figure out for sure what is happening. 

http://theoutpost.io/view/nodejs

will give you instructions on how to debug chrome in the browser.
