### PR TITLE
Switch to Puma for web server instead of Thin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "sinatra", '1.2.6'
 gem "haml"
 gem "sass"
 gem "json"
-gem "thin"
+gem "puma"
 gem "RubyInline"
 gem "ZenTest", '<= 4.6.0'   # dependency of RubyInline, newer versions break Heroku deploy
 gem "png"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,7 @@ GEM
       mime-types (~> 1.15)
       multi_json (~> 1.0)
       rest-client (~> 1.6.1)
-    daemons (1.1.8)
     diff-lcs (1.1.3)
-    eventmachine (0.12.10)
-    eventmachine (0.12.10-java)
     excon (0.15.5)
     ffi (1.1.3)
     ffi (1.1.3-java)
@@ -57,6 +54,8 @@ GEM
     nokogiri (1.5.5)
     nokogiri (1.5.5-java)
     png (1.2.0)
+    puma (1.6.3)
+      rack (~> 1.2)
     rack (1.4.1)
     rack-test (0.5.6)
       rack (>= 1.0)
@@ -100,10 +99,6 @@ GEM
       rack (~> 1.1)
       tilt (>= 1.2.2, < 2.0)
     spoon (0.0.1)
-    thin (1.4.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     tilt (1.3.3)
     xpath (0.1.4)
       nokogiri (~> 1.3)
@@ -123,6 +118,7 @@ DEPENDENCIES
   launchy
   memcache-client
   png
+  puma
   rack-test (= 0.5.6)
   rake
   rest-client
@@ -136,4 +132,3 @@ DEPENDENCIES
   sass
   selenium-webdriver (= 2.22.2)
   sinatra (= 1.2.6)
-  thin

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec thin start -R server/sinatra/config.ru -p $PORT
+web: bundle exec puma -C server/sinatra/procfile_puma_config.rb -e production -p $PORT

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -113,7 +113,7 @@ The server is a ruby bundle. Get the bundler gem and then use it to get everythi
 Launch the server with this bundle command:
 
 	cd server/sinatra
-	bundle exec rackup -s thin -p 1111
+	bundle exec rackup -s puma -p 1111
 
 Now go to your browser and browse your new wiki:
 
@@ -174,5 +174,5 @@ for those not using Ruby much, but using Debian:
     sudo gem install bundle
     sudo /var/lib/gems/1.8/bin/bundle install
     rvm 1.9.2
-    /var/lib/gems/1.8/bin/bundle exec rackup -s thin -p 1111
+    /var/lib/gems/1.8/bin/bundle exec rackup -s puma -p 1111
 

--- a/server/sinatra/procfile_puma_config.rb
+++ b/server/sinatra/procfile_puma_config.rb
@@ -1,0 +1,1 @@
+rackup './server/sinatra/config.ru'


### PR DESCRIPTION
Sinatra prior to 1.3 uses "EventMachine" mode of Thin, which disables Ruby
threading. This can dramatically decrease throughput on JRuby and 
Rubinius, because it cannot take advantage of multiple CPU cores with
this configuration.

In addition, the MRI (Matz Ruby Implementation) C version of Ruby has a
pattern where it will not block on IO if threading is used, because IO
will run in the background concurrently while work is being done on
other threads.

Unfortunately, Thin with Sinatra < 1.3 forcibly turns threading off due 
to EventMachine, which makes it so the server has to stop and wait for 
external IO requests to finish until it can continue serving content (the
exception being if you use the special EventMachine drivers, which are 
very difficult to implement).

Puma does not have these restrictions. It is a fast, clean
implementation based on threads, and should run well on all Ruby
implementations. It should increase throughput dramatically vs Thin for 
sites doing a lot of remote IO. It also has a lot of power features like
HTTP Keepalive. And best of all, it removes the EventMachine dependency!

More information is available from their web site: http://puma.io

This is a fairly big change, so it would be great if a few people tested it and gave it a thumbs up before merging. An alternative solution to this would be to upgrade to a Sinatra >= 1.3 and the latest version of Thin, which will automatically use threaded mode by default, but this seemed like the more conservative option of the two. That said, ultimately it might be nice to upgrade to 1.3+ as well.

I deployed to Heroku with this change and it appears to be working just fine!
