### PR TITLE
Initial tablet work

### DIFF
--- a/server/sinatra/views/layout.haml
+++ b/server/sinatra/views/layout.haml
@@ -4,6 +4,7 @@
 		%title Smallest Federated Wiki
 		/
 			= settings.versions
+		
 		%meta(http-equiv="Content-Type" content="text/html; charset=UTF-8")
 		%meta(name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=no")
 		%link(type="image/png" href="/favicon.png" rel="icon")
@@ -13,6 +14,13 @@
 		%link(type="text/css" href="/js/jquery-ui-1.8.16.custom.css" rel="stylesheet")
 		%script(type="text/javascript" src="/js/underscore-min.js")
 		%script(type="text/javascript" src="/client.js")
+		
+		%meta(name="apple-mobile-web-app-capable" content="yes")
+		%meta(name="apple-mobile-web-app-status-bar-style" content="black")
+		%meta(name="apple-mobile-web-app-title" content="SF Wiki")
+		
+		%link(rel="apple-touch-icon" href="/favicon.png")
+		%link(rel="shortcut icon" href="/favicon.png")
 	%body
 		%section.main
 			=yield


### PR DESCRIPTION
Now that I have some free time (and, more importantly, an iPad) I have started work on optimizing SFW to work on tablets. This small pull request is mostly meant to check my master is up to date with what you guys are doing and that I can get reasonable-quality screencasts from the iPad simulator. 

The code changes include new meta tags specific to iOS, which enable:
- adding a SFW site to your home page as if it were an app
- setting the app's icon to be the site's gradient favicon
- showing SFW, when opened in app mode, without the browser chrome

For those who don't have iPads handy, here is a short screencast of what it looks like: http://www.youtube.com/watch?v=0_OwELpSg7s&feature=youtu.be

As you can see in the video, some bits of the layout don't work on the iPad. Notably the stories all scroll together and are arbitrary height, instead of just scrolling within fixed-height containers as they do in desktop browsers. Buttons and form controls are less than optimal, and there are various other problems. I'll be working on these items to get SFW to the point of being usable as a personal notebook on the iPad.
