### PR TITLE
remove line breaks in literals

### DIFF
--- a/client/plugins/changes/changes.coffee
+++ b/client/plugins/changes/changes.coffee
@@ -1,11 +1,6 @@
 listItemHtml = (slug, page)->
   """
-    <li>
-      <a class="internal" href="#" title="local" data-page-name="#{slug}" data-site="local">
-        #{page.title}
-      </a> 
-      <button class="delete">✕</button>
-    </li>
+    <li><a class="internal" href="#" title="local" data-page-name="#{slug}" data-site="local">#{page.title}</a> <button class="delete">✕</button></li>
   """
 
 pageBundle = ->

--- a/client/plugins/changes/changes.js
+++ b/client/plugins/changes/changes.js
@@ -3,7 +3,7 @@
   var constructor, listItemHtml, pageBundle;
 
   listItemHtml = function(slug, page) {
-    return "<li>\n  <a class=\"internal\" href=\"#\" title=\"local\" data-page-name=\"" + slug + "\" data-site=\"local\">\n    " + page.title + "\n  </a> \n  <button class=\"delete\">✕</button>\n</li>";
+    return "<li><a class=\"internal\" href=\"#\" title=\"local\" data-page-name=\"" + slug + "\" data-site=\"local\">" + page.title + "</a> <button class=\"delete\">✕</button></li>";
   };
 
   pageBundle = function() {

--- a/client/plugins/factory/factory.coffee
+++ b/client/plugins/factory/factory.coffee
@@ -5,11 +5,7 @@ window.plugins.factory =
       menu = div.find('p').append "<br>Or Choose a Plugin"
       menuItem = (title, name) ->
         menu.append """
-          <li>
-            <a class="menu" href="#" title="#{title}">
-              #{name}
-            </a>
-          </li>
+          <li><a class="menu" href="#" title="#{title}">#{name}</a></li>
         """
       if Array.isArray window.catalog
         menuItem(info.title, info.name) for info in window.catalog

--- a/client/plugins/factory/factory.js
+++ b/client/plugins/factory/factory.js
@@ -11,7 +11,7 @@
         var info, menu, menuItem, name, _i, _len, _ref, _ref1;
         menu = div.find('p').append("<br>Or Choose a Plugin");
         menuItem = function(title, name) {
-          return menu.append("<li>\n  <a class=\"menu\" href=\"#\" title=\"" + title + "\">\n    " + name + "\n  </a>\n</li>");
+          return menu.append("<li><a class=\"menu\" href=\"#\" title=\"" + title + "\">" + name + "</a></li>");
         };
         if (Array.isArray(window.catalog)) {
           _ref = window.catalog;


### PR DESCRIPTION
Resolves problems with having a '\n' in the links.

Causes errors like  "GET /plugins/%20%20%20%20code%20%20/%20%20%20%20code%20%20.js?_=1360492515383 HTTP/1.1", with  Firefox.

The changes to factory.coffee, are duplicated from WardCunningham/Smallest-Federated-Wiki@cd51799, and changes.coffee also modified as it introduces '\n' into links.

This is a know Coffee script problem (all be it closed) - see jashkenas/coffee-script#240
