### PR TITLE
Change default pages to suggest ALT-S, not CTRL-S. (See Issue #126)

### DIFF
--- a/default-data/pages/welcome-visitors
+++ b/default-data/pages/welcome-visitors
@@ -9,7 +9,7 @@
     {
       "type": "paragraph",
       "id": "821827c99b90cfd1",
-      "text": "<b>One:</b> Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/CTRL-S to save."
+      "text": "<b>One:</b> Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/ALT-S to save."
     },
     {
       "type": "factory",
@@ -18,7 +18,7 @@
     {
       "type": "paragraph",
       "id": "2bbd646ff3f44b51",
-      "text": "<b>Two:</b> Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/CTRL-S to save."
+      "text": "<b>Two:</b> Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/ALT-S to save."
     },
     {
       "type": "factory",
@@ -69,7 +69,7 @@
       "item": {
         "type": "paragraph",
         "id": "821827c99b90cfd1",
-        "text": "<b>One:</b> Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/CTRL-S to save."
+        "text": "<b>One:</b> Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/ALT-S to save."
       },
       "after": "7b56f22a4b9ee974",
       "id": "821827c99b90cfd1",
@@ -90,7 +90,7 @@
       "item": {
         "type": "paragraph",
         "id": "2bbd646ff3f44b51",
-        "text": "<b>Two:</b> Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/CTRL-S to save."
+        "text": "<b>Two:</b> Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/ALT-S to save."
       },
       "after": "63ad2e58eecdd9e5",
       "id": "2bbd646ff3f44b51",


### PR DESCRIPTION
In my experience, CTRL-S opens the browser's Save Page dialog. Since that takes focus, it does cause the current edit to save, but it's not ideal. ALT-S is the key to use.
