### PR TITLE
Fix for truncated favicon.png (Windows/Sinatra)

### DIFF
--- a/server/sinatra/stores/file.rb
+++ b/server/sinatra/stores/file.rb
@@ -7,7 +7,9 @@ class FileStore < Store
       File.read path if File.exist? path
     end
 
-    alias_method :get_blob, :get_text
+    def get_blob(path)
+      File.binread path if File.exist? path
+    end
 
     ### PUT
 


### PR DESCRIPTION
Fix candidate for #362

Read blob file in binary mode - binread being the equivalent of opening the file in `rb:ASCII-8BIT` for reading. This "Suppresses EOL <-> CRLF conversion on Windows, as well as setting external encoding to ASCII-8BIT"
