### PR TITLE
Simple leveldb store.

### DIFF
--- a/server/express/lib/leveldb.js
+++ b/server/express/lib/leveldb.js
@@ -1,0 +1,25 @@
+var path = require('path')
+
+  , levelup = require('levelup')
+
+  , fsPage = require('./page')
+
+module.exports = function (opts) {
+  var db = levelup(path.join(opts.db, 'pagedb'), {encoding: 'json'})
+    , classicPageGet = fsPage(opts).get
+  function put (file, page, cb) {
+    db.put(file, page, cb)
+  }
+  function get (file, cb) {
+    db.get(file, function (e, page) {
+      if (e) {
+        console.log(e)
+        if (e.name !== 'NotFoundError') return cb(e)
+        return classicPageGet(file, cb)
+      }
+      cb(null, page)
+    })
+  }
+
+  return { put: put, get: get }
+}

--- a/server/express/lib/page.coffee
+++ b/server/express/lib/page.coffee
@@ -18,7 +18,7 @@ module.exports = exports = (argv) ->
   #### Private utility methods. ####
   load_parse = (loc, cb) ->
     fs.readFile(loc, (err, data) ->
-      if err then cb(err)
+      return cb(err) if err
       try 
         page = JSON.parse(data)
         if m = loc.match /plugins\/(.+?)\/pages/

--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -38,8 +38,8 @@ pluginsFactory = require './plugins'
 
 # pageFactory can be easily replaced here by requiring your own page handler
 # factory, which gets called with the argv object, and then has get and put
-# methods that accept the same arguments and callbacks. That would be the
-# easiest way to use the Smallest Federated Wiki with a database backend.
+# methods that accept the same arguments and callbacks.
+# Currently './page' and './leveldb' are provided.
 pageFactory = require './page'
 
 render = (page) ->


### PR DESCRIPTION
Oddly the levelup api looks pretty much like the pagehandler api, so all I had to do was check for pages that don't exist on get and fall back to the fs store. This lets us get plugin and default-data pages without having to replicate that logic. It has the interesting side effect of putting a wiki used with the file system store into read only mode, such that old pages can be read, until they are modified and the db copy shadows them. I kind of like it, but if we don't want that we can refactor out the static page handling into it's own thing, and require it with each new store.
