### PR TITLE
Node: restrict system/factories.json to looking in plugins

### DIFF
--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -297,7 +297,7 @@ module.exports = exports = (argv) ->
   app.get ///system/factories.json///, (req, res) ->
     res.status(200)
     res.header('Content-Type', 'application/json')
-    glob path.join(argv.c, '**', 'factory.json'), (e, files) ->
+    glob path.join(argv.c, 'plugins', '**', 'factory.json'), (e, files) ->
       if e then return res.e(e)
       files = files.map (file) ->
         return fs.createReadStream(file).on('error', res.e).pipe(JSONStream.parse())


### PR DESCRIPTION
This corrects the first part of #376, but still need to understand if the second part is a glob fault...
