### PR TITLE
Don't use globstar, it's not needed...

### DIFF
--- a/server/express/lib/server.coffee
+++ b/server/express/lib/server.coffee
@@ -297,7 +297,7 @@ module.exports = exports = (argv) ->
   app.get ///system/factories.json///, (req, res) ->
     res.status(200)
     res.header('Content-Type', 'application/json')
-    glob path.join(argv.c, 'plugins', '**', 'factory.json'), (e, files) ->
+    glob path.join(argv.c, 'plugins', '*', 'factory.json'), (e, files) ->
       if e then return res.e(e)
       files = files.map (file) ->
         return fs.createReadStream(file).on('error', res.e).pipe(JSONStream.parse())


### PR DESCRIPTION
Further change to the glob - not using globstar '**' - so it does not look into any of the plugin's subdirectories.
