### PR TITLE
Gemfile cleanup - remove outdated heroku gem, and use HTTPS address for rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RubyInline (3.12.1)
       ZenTest (~> 4.3)


### PR DESCRIPTION
Silences warnings.  Addresses #380.
