### PR TITLE
Add Dockerfile to repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ run apt-get install -y libxml2-dev libxslt-dev build-essential git
 run gem install nokogiri -v '1.5.6'
 add . /wiki
 expose 1111
-run cd /wiki && bundle install
+run cd /wiki && bundle install --without development test
 cmd cd /wiki/server/sinatra && bundle exec rackup -s thin -p 1111


### PR DESCRIPTION
Add Dockerfile. This allows people to call `docker build github.com/WardCunningham/Smallest-Federated-Wiki`. This will build the image from which you can run the federated wiki software. It exposes port 1111 to a random port on the host.
