### PR TITLE
Add /wiki/data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ run apt-get install -y libxml2-dev libxslt-dev build-essential git
 run gem install nokogiri -v '1.5.6'
 add . /wiki
 expose 1111
+volume /wiki/data
 run cd /wiki && bundle install --without development test
 cmd cd /wiki/server/sinatra && bundle exec rackup -s thin -p 1111


### PR DESCRIPTION
This change to the Dockerfile adds a volume for /wiki/data, which contains the changing data.
In a test I have use the following to make this work:

```
# create data dir
mkdir /home/<user>/wiki-data
# build image
docker build github.com/WardCunningham/Smallest-Federated-Wiki
-> <image>
# run container
docker run -d -v /home/<user>/wiki-data:/wiki/data <image>
-> <container>
# find port
docker port <container> 1111
-> <port>
# Visit http://localhost:<port>
```
